### PR TITLE
DrawView's superview receive "touches" methods too now.

### DIFF
--- a/Classes/DrawView.m
+++ b/Classes/DrawView.m
@@ -208,6 +208,8 @@
         [bezierPath moveToPoint:[currentTouch locationInView:self]];
         [paths addObject:bezierPath];
     }
+    
+    [super touchesBegan:touches withEvent:event];
 }
 - (void)touchesMoved:(NSSet *)touches withEvent:(UIEvent *)event{
     if (_canEdit){


### PR DESCRIPTION
Currently DrawView's superview doesn't receive "touchesBegan:", "touchesMoved:", etc methods.
I've fixed this issue.